### PR TITLE
feat: Add DCO Checker pipeline

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,30 @@
+name: DCO
+on:
+  workflow_call:
+    inputs:
+      exclude-emails:
+        type: string
+        description: 'Comma-separated list of emails that should be ignored during DCO checks'
+        required: false
+        default: ''
+  pull_request:
+  push:
+    branches:
+      - "main"
+jobs:
+  dco-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Check DCO
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DCO_CHECK_VERBOSE: '1'
+          DCO_CHECK_EXCLUDE_EMAILS: ${{ inputs.exclude-emails }}
+        run: |
+          pip3 install -U dco-check
+          dco-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/


### PR DESCRIPTION
### This PR
* Adds a pipeline that check the DCO.
* Enables the pipeline to be used from other repos through the `workflow_call` event.
* Adds a basic gitignore file

#### Notes
More info on `workflow_call` events can be found [here](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows)